### PR TITLE
use git status --porcelain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ module.exports = function gitDiffApply(options) {
   let endTag = options.endTag;
   let ignoreConflicts = options.ignoreConflicts;
 
-  if (!isGitClean(run('git status'))) {
+  if (!isGitClean(run('git status --porcelain'))) {
     return Promise.reject('You must start with a clean working directory');
   }
 

--- a/src/is-git-clean.js
+++ b/src/is-git-clean.js
@@ -1,11 +1,5 @@
 'use strict';
 
-const detachedRegex = /^HEAD detached at/m;
-const cleanRegex = /^nothing to commit, working tree clean$/m;
-
 module.exports = function(output) {
-  return !!(
-    !output.match(detachedRegex) &&
-    output.match(cleanRegex)
-  );
+  return !output;
 };

--- a/test/unit/is-git-clean-test.js
+++ b/test/unit/is-git-clean-test.js
@@ -4,30 +4,12 @@ const expect = require('chai').expect;
 const isGitClean = require('../../src/is-git-clean');
 
 describe('Unit - is-git-clean', function() {
-  it('detects detached head', function() {
-    expect(isGitClean(`
-HEAD detached at 7036c83
-nothing to commit, working tree clean
-`)).to.be.false;
-  });
-
   it('detects clean', function() {
-    expect(isGitClean(`
-On branch master
-Your branch is up-to-date with 'origin/master'.
-
-nothing to commit, working tree clean
-`)).to.be.true;
+    expect(isGitClean('')).to.be.true;
   });
 
   it('detects dirty', function() {
-    expect(isGitClean(`
-On branch master
-Your branch is up-to-date with 'origin/master'.
-
-Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
+    expect(isGitClean(`?? jkladsfjl
 `)).to.be.false;
   });
 });


### PR DESCRIPTION
Closes #43.

We lose detached HEAD detection, but that may be OK? cc @rwjblue 