### PR TITLE
Skip pre-commit hooks when commiting

### DIFF
--- a/src/commit.js
+++ b/src/commit.js
@@ -8,6 +8,7 @@ module.exports = function commit(options) {
 
   // it's possible for there to be no changes between tags
   if (!isGitClean(options)) {
-    run('git commit -m "message"', options);
+    // run with --no-verify to skip pre-commit application level hooks
+    run('git commit -m "message" --no-verify', options);
   }
 };


### PR DESCRIPTION
These application level hooks should be skipped when making empty
commits

Refs ember-cli/ember-cli-update#332