### PR TITLE
Fix to support spaces in file names

### DIFF
--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -19,6 +19,6 @@ module.exports = co.wrap(function* gitRemoveAll(options) {
 
     yield fs.remove(path.join(options.cwd, file));
 
-    run(`git add ${file}`, options);
+    run(`git add "${file}"`, options);
   }
 });


### PR DESCRIPTION
ember-cli-update fails due to files with spaces in them, due to an upstream issue with git-diff-apply. This issue fixes that downstream.

It also fixes https://github.com/ember-cli/ember-cli-update/issues/540