### PR TITLE
revert to fs.move

### DIFF
--- a/src/merge-dir.js
+++ b/src/merge-dir.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const co = require('co');
+const path = require('path');
 const fs = require('fs-extra');
 const klaw = require('klaw');
 const copyRegex = require('./copy-regex');
@@ -29,8 +30,20 @@ module.exports = co.wrap(function* mergeDir(from, to) {
       if (item.stats.isDirectory()) {
         promise = fs.ensureDir(toFile);
       } else {
-        // `fs.move` doesn't handle broken symlinks
-        promise = fs.rename(fromFile, toFile);
+        // `fs.rename` can throw EXDEV if across partitions
+        promise = fs.move(fromFile, toFile).catch(co.wrap(function*(err) {
+          // `fs.move` doesn't handle broken symlinks
+          // https://github.com/jprichardson/node-fs-extra/issues/638
+          if (!err.message.startsWith('ENOENT: no such file or directory, stat')) {
+            throw err;
+          }
+          // reimplement `fs.rename`...
+          let brokenSymlink = yield fs.readlink(fromFile);
+          let absolute = path.resolve(path.dirname(fromFile), brokenSymlink);
+          yield fs.ensureFile(absolute);
+          yield fs.move(fromFile, toFile);
+          yield fs.unlink(absolute);
+        }));
       }
       promises.push(promise);
     }).on('error', (err, item) => {

--- a/test/integration/index-test.js
+++ b/test/integration/index-test.js
@@ -765,10 +765,10 @@ D  removed-unchanged.txt
     let realpath = {};
 
     let createBrokenSymlink = co.wrap(function* (srcpath, dstpath) {
-      yield fs.ensureFile(srcpath);
+      yield fs.ensureFile(path.resolve(localDir, srcpath));
       yield fs.symlink(srcpath, dstpath);
-      realpath[srcpath] = yield fs.realpath(srcpath);
-      yield fs.remove(srcpath);
+      realpath[srcpath] = yield fs.realpath(path.resolve(localDir, srcpath));
+      yield fs.remove(path.resolve(localDir, srcpath));
     });
 
     let assertBrokenSymlink = co.wrap(function* (srcpath, dstpath) {
@@ -780,7 +780,7 @@ D  removed-unchanged.txt
       remoteFixtures: 'test/fixtures/remote/gitignored',
       beforeMerge: co.wrap(function* () {
         yield createBrokenSymlink(
-          path.join(localDir, 'broken'),
+          path.normalize('./broken'),
           path.join(localDir, 'local-only')
         );
       })


### PR DESCRIPTION
We get EXDEV handling, but now have to do broken symlink handling...