### PR TITLE
Fix ls-files call in large monorepos

### DIFF
--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -5,16 +5,23 @@ const path = require('path');
 const run = require('./run');
 const { runWithSpawn } = require('./run');
 
+async function lsFiles(options) {
+  // Using spawn rather than run here because ls-files produces a lot
+  // of output if it gets run in a large repo.
+  // See https://github.com/kellyselden/git-diff-apply/pull/277
+  let files = (await runWithSpawn('git', ['ls-files'], options))
+    .split(/\r?\n/g)
+    .filter(Boolean);
+
+  return files;
+}
+
 module.exports = async function gitRemoveAll(options) {
   // this removes cwd as well, which trips up your terminal
   // when in a monorepo
   // await run('git rm -rf .', options);
 
-  // Using spawn rather than run here because ls-files produces a lot
-  // of output if it gets run in a large repo
-  let files = (await runWithSpawn('git', ['ls-files'], options))
-    .split(/\r?\n/g)
-    .filter(Boolean);
+  let files = await lsFiles(options);
 
   for (let file of files) {
     // this removes folders that become empty,

--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -3,7 +3,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const run = require('./run');
-const {runWithSpawn} = require('./run');
+const { runWithSpawn } = require('./run');
 
 module.exports = async function gitRemoveAll(options) {
   // this removes cwd as well, which trips up your terminal
@@ -12,7 +12,9 @@ module.exports = async function gitRemoveAll(options) {
 
   // Using spawn rather than run here because ls-files produces a lot
   // of output if it gets run in a large repo
-  let files = (await runWithSpawn('git', ['ls-files'], options)).split(/\r?\n/g);
+  let files = (await runWithSpawn('git', ['ls-files'], options))
+    .split(/\r?\n/g)
+    .filter(Boolean);
 
   for (let file of files) {
     // this removes folders that become empty,

--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -3,22 +3,16 @@
 const fs = require('fs-extra');
 const path = require('path');
 const run = require('./run');
-
-async function lsFiles(options) {
-  // attempt to fix https://github.com/ember-cli/ember-cli-update/issues/583
-  options = { maxBuffer: 500 * 1024, ...options };
-
-  let files = (await run('git ls-files', options)).trim().split(/\r?\n/g);
-
-  return files;
-}
+const {runWithSpawn} = require('./run');
 
 module.exports = async function gitRemoveAll(options) {
   // this removes cwd as well, which trips up your terminal
   // when in a monorepo
   // await run('git rm -rf .', options);
 
-  let files = await lsFiles(options);
+  // Using spawn rather than run here because ls-files produces a lot
+  // of output if it gets run in a large repo
+  let files = (await runWithSpawn('git', ['ls-files'], options)).split(/\r?\n/g);
 
   for (let file of files) {
     // this removes folders that become empty,

--- a/src/run.js
+++ b/src/run.js
@@ -14,13 +14,13 @@ module.exports = async function run(command, options) {
 
 module.exports.runWithSpawn = async function runWithSpawn(cmd, args, options) {
   return await new Promise(function(resolve, reject) {
-    const command = [cmd, ...args].join(' ');
+    let command = [cmd, ...args].join(' ');
     let stdout = '';
     let errorMessage = '';
 
     debug(command);
 
-    const child = spawn(cmd, args, options);
+    let child = spawn(cmd, args, options);
     child.stdout.on('data', function(data) {
       stdout += data;
     });

--- a/src/run.js
+++ b/src/run.js
@@ -1,12 +1,38 @@
 'use strict';
 
 const { promisify } = require('util');
-const exec = promisify(require('child_process').exec);
+const { exec, spawn } = require('child_process');
 const debug = require('debug')('git-diff-apply');
+const execPromise = promisify(exec);
 
 module.exports = async function run(command, options) {
   debug(command);
-  let { stdout } = await exec(command, options);
+  let { stdout } = await execPromise(command, options);
   debug(stdout);
   return stdout;
+};
+
+module.exports.runWithSpawn = async function runWithSpawn(cmd, args, options) {
+  return await new Promise(function(resolve, reject) {
+    const command = [cmd, ...args].join(' ');
+    let stdout = '';
+    let errorMessage = '';
+
+    debug(command);
+
+    const child = spawn(cmd, args, options);
+    child.stdout.on('data', function(data) {
+      stdout += data;
+    });
+    child.stderr.on('data', function(data) {
+      errorMessage += data;
+    });
+    child.on('close', function(status) {
+      if (status === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`${command} failed with message ${errorMessage}`));
+      }
+    });
+  });
 };


### PR DESCRIPTION
I came across this issue when trying to run `ember-cli-update` in a large monorepo.  It kept giving errors which led me to https://github.com/kellyselden/git-diff-apply/pull/269 and the accompanying issue https://github.com/ember-cli/ember-cli-update/issues/583.

The fix in the above PR did not create a big enough buffer for the monorepo I was trying to use this on.  Rather than trying to bump up the buffer size again which seems to not be a general solution I created a secondary command execution strategy which uses `spawn` rather than `exec` because `spawn` is a stream rather than a buffer.  This seems to fix the problem although the runtime is quite long still for such a big repo.

Happy to make any tweaks necessary or rethink things if it helps.