### PR TITLE
Performance optimizations for large monorepo

### DIFF
--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const run = require('./run');
 const { runWithSpawn } = require('./run');
 
 async function lsFiles(options) {
@@ -16,20 +15,41 @@ async function lsFiles(options) {
   return files;
 }
 
+function chunkFilePaths(files, maxChunkSize = 2048) {
+  let currentChunkLength = 0;
+  let currentChunkIndex = 0;
+  let chunkedOutput = [[]];
+
+  files.forEach(file => {
+    if (currentChunkLength + file.length <= maxChunkSize) {
+      chunkedOutput[currentChunkIndex].push(file);
+      currentChunkLength += file.length;
+    } else {
+      chunkedOutput.push([file]);
+      currentChunkLength = file.length;
+      currentChunkIndex += 1;
+    }
+  });
+
+  return chunkedOutput;
+}
+
 module.exports = async function gitRemoveAll(options) {
   // this removes cwd as well, which trips up your terminal
   // when in a monorepo
   // await run('git rm -rf .', options);
 
   let files = await lsFiles(options);
+  let fileGroups = chunkFilePaths(files);
 
-  for (let file of files) {
+  for (let files of fileGroups) {
     // this removes folders that become empty,
     // which we are trying to avoid
     // await run(`git rm -f "${file}"`, options);
+    for (let file of files) {
+      await fs.remove(path.join(options.cwd, file));
+    }
 
-    await fs.remove(path.join(options.cwd, file));
-
-    await run(`git add "${file}"`, options);
+    await runWithSpawn('git', ['add', ...files], options);
   }
 };

--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -15,7 +15,7 @@ async function lsFiles(options) {
   return files;
 }
 
-function chunkFilePaths(files, maxChunkSize = 2048) {
+function chunkFilePaths(files, maxChunkSize = 4096) {
   let currentChunkLength = 0;
   let currentChunkIndex = 0;
   let chunkedOutput = [[]];

--- a/src/git-remove-all.js
+++ b/src/git-remove-all.js
@@ -18,10 +18,11 @@ async function lsFiles(options) {
 function chunkFilePaths(files, maxChunkSize = 4096) {
   let currentChunkLength = 0;
   let currentChunkIndex = 0;
-  let chunkedOutput = [[]];
+  let chunkedOutput = [];
 
   files.forEach(file => {
     if (currentChunkLength + file.length <= maxChunkSize) {
+      chunkedOutput[currentChunkIndex] = chunkedOutput[currentChunkIndex] || [];
       chunkedOutput[currentChunkIndex].push(file);
       currentChunkLength += file.length;
     } else {
@@ -53,3 +54,5 @@ module.exports = async function gitRemoveAll(options) {
     await runWithSpawn('git', ['add', ...files], options);
   }
 };
+
+module.exports.chunkFilePaths = chunkFilePaths;

--- a/src/git-status.js
+++ b/src/git-status.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const run = require('./run');
+const { runWithSpawn } = require('./run');
 
 async function gitStatus(options) {
-  return await run('git status --porcelain', options);
+  return await runWithSpawn('git', ['status', '--porcelain'], options);
 }
 
 async function isGitClean(options) {

--- a/test/unit/chunk-file-paths-test.js
+++ b/test/unit/chunk-file-paths-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { describe, it } = require('../helpers/mocha');
+const { expect } = require('chai');
+const { chunkFilePaths } = require('../../src/git-remove-all');
+const filePaths = [
+  'a'.repeat(5),
+  'b'.repeat(4),
+  'c'.repeat(2)
+];
+
+describe(chunkFilePaths, function() {
+  it('divides the input into chunks', function() {
+    let result = chunkFilePaths(filePaths, 6);
+    expect(result).to.have.lengthOf(2);
+    expect(result[0]).to.have.lengthOf(1);
+    expect(result[0]).to.deep.equal([filePaths[0]]);
+    expect(result[1]).to.have.lengthOf(2);
+    expect(result[1]).to.deep.equal([filePaths[1], filePaths[2]]);
+  });
+
+  it('handles everything being in the same chunk', function() {
+    let result = chunkFilePaths(filePaths, 1000);
+    expect(result).to.have.lengthOf(1);
+    expect(result[0]).to.deep.equal(filePaths);
+  });
+
+  it('handles when individual elements are bigger than the chunk size', function() {
+    let result = chunkFilePaths(filePaths, 4);
+    expect(result).to.have.lengthOf(3);
+    expect(result[0]).to.deep.equal([filePaths[0]]);
+    expect(result[1]).to.deep.equal([filePaths[1]]);
+  });
+});


### PR DESCRIPTION
I've been trying to run ember-cli-update on a large monorepo and ran into some problems. First I addressed the functional issue I found with git command buffers with PR https://github.com/kellyselden/git-diff-apply/pull/277 which was a result of run `git ls-files` on a repo with more than 15k files in it.  After merging that I found that while ember-cli-update was working it was extremely slow which I figured was because it ran a large number of git commands.

This pull request addresses two things:

1) Before these changes it needed to run `git add <file-path>` on more than 15k files individually which took a very long time.  Batching the files within a certain command size (started with 4k characters each) sped it up considerably by reducing the number of git commands to run to under 500.

2) `git status --porcelain` could have a very large output size because many files could be in the git staging area after adding. I fixed this by using the spawn based command runner that I added in the previous pull request.

I hope this is helpful, trying to get to the point where I can easily run `ember-cli-update` on my mid-sized ember project that is embedded in a large monorepo without issues and it seems to work pretty well with these changes.