### PR TITLE
refactor(src/run.js): use spawn instead of exec

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -9,15 +9,8 @@ const run = async function run(command, options = {}) {
   // problems when handling quotes and whitespace.
   options.shell = true;
   debug(command);
-  let [
-    cmd,
-    ...args
-  ] = command.split(' ');
-  let stdout = await runWithSpawn(
-    cmd,
-    args,
-    options
-  );
+  let [cmd, ...args] = command.split(' ');
+  let stdout = await runWithSpawn(cmd, args, options);
   debug(stdout);
   return stdout;
 };

--- a/src/run.js
+++ b/src/run.js
@@ -1,25 +1,24 @@
 'use strict';
 
-const { promisify } = require('util');
-const { exec, spawn } = require('child_process');
+const { spawn } = require('child_process');
 const debug = require('debug')('git-diff-apply');
-const execPromise = promisify(exec);
 
-module.exports = async function run(command, options) {
+const run = async function run(command, options) {
   debug(command);
-  let { stdout } = await execPromise(command, options);
+  let cmdArr = command.split(' ');
+  let [cmd, ...args] = cmdArr;
+  let stdout = await runWithSpawn(cmd, args, options);
   debug(stdout);
   return stdout;
 };
 
-module.exports.runWithSpawn = async function runWithSpawn(cmd, args, options) {
+const runWithSpawn = async function runWithSpawn(cmd, args, options) {
   return await new Promise(function(resolve, reject) {
     let command = [cmd, ...args].join(' ');
     let stdout = '';
     let errorMessage = '';
 
     debug(command);
-
     let child = spawn(cmd, args, options);
     child.stdout.on('data', function(data) {
       stdout += data;
@@ -36,3 +35,6 @@ module.exports.runWithSpawn = async function runWithSpawn(cmd, args, options) {
     });
   });
 };
+
+module.exports = run;
+module.exports.runWithSpawn = runWithSpawn;

--- a/src/run.js
+++ b/src/run.js
@@ -3,11 +3,21 @@
 const { spawn } = require('child_process');
 const debug = require('debug')('git-diff-apply');
 
-const run = async function run(command, options) {
+const run = async function run(command, options = {}) {
+  // Matches the shell-enabled behaviour of child_process.exec, which this
+  // function previously used to run the specified command. This avoids
+  // problems when handling quotes and whitespace.
+  options.shell = true;
   debug(command);
-  let cmdArr = command.split(' ');
-  let [cmd, ...args] = cmdArr;
-  let stdout = await runWithSpawn(cmd, args, options);
+  let [
+    cmd,
+    ...args
+  ] = command.split(' ');
+  let stdout = await runWithSpawn(
+    cmd,
+    args,
+    options
+  );
   debug(stdout);
   return stdout;
 };


### PR DESCRIPTION
In a large monorepo the output from running some git commands can be huge. The default max size for stdout that child_process.exec can handle is 200KB, we 'hacked' this for a quickfix in our repo but the ling term fix is `spawn`. This PR leverages off the work done in #277. 

This should address the issue raised here: https://github.com/ember-cli/ember-cli-update/issues/583