### PR TITLE
Allow overriding conflict resolution process options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "git-diff-apply",
+  "name": "@phated/git-diff-apply",
   "version": "0.22.10",
-  "description": "Use an unrelated remote repository to apply a git diff",
+  "description": "(Fork) Use an unrelated remote repository to apply a git diff",
   "main": "src",
   "files": [
     "bin",

--- a/src/index.js
+++ b/src/index.js
@@ -288,7 +288,8 @@ module.exports = async function gitDiffApply({
   }
 
   if (hasConflicts && _resolveConflicts) {
-    returnObject.resolveConflictsProcess = resolveConflicts({ cwd });
+    let processOpts = typeof _resolveConflicts === 'object' ? _resolveConflicts : {};
+    returnObject.resolveConflictsProcess = resolveConflicts({ cwd, ...processOpts });
   }
 
   return returnObject;


### PR DESCRIPTION
While using `boilerplate-update`, we ran into a scenario where a file was modified in the project being updated but that same file is deleted in the boilerplate. This caused the process to just hang because Meld doesn't handle this style of conflict.

By passing an options object through to the spawned process, it can be set to `stdio: 'inherit'` which allows us to handle that scenario in our terminal.

I made wrote this change so nothing changes for the `resolveConflicts: true` use case.

Ref: https://github.com/gulpjs/update-template/issues/1#issuecomment-640555773