### PR TITLE
Update arguments passed to git in `createPathFile()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ module.exports = async function gitDiffApply({
 
   async function createPatchFile() {
     let patchFile = path.join(await createTmpDir(), 'file.patch');
-    let ps = spawn('git', ['diff', safeStartTag, safeEndTag, '--binary'], { cwd: _tmpDir });
+    let ps = spawn('git', ['diff', '--no-ext-diff', '--patience', '--binary', safeStartTag, safeEndTag], { cwd: _tmpDir });
     ps.stdout.pipe(fs.createWriteStream(patchFile));
     await ps;
     if (await fs.readFile(patchFile, 'utf8') !== '') {


### PR DESCRIPTION
- Corrects the order of arguments per Git CLI conventions (flags go first) (this broke for me because of odd tag names)
- Adds two new flags to improve edge cases
  - `--no-ext-diff` ensures configured external diff tools will not interfere in a non-interactive task (this broke `ember-cli-update` on my machine)
  - `--patience` is available since Git 1.6.2 (2009) produces better (more consistent) diffs at negligible slower execution time (this is just good practice)


---

This work is supported by the [Mainmatter Ember Initiative](https://mainmatter.com/ember-initiative/). 